### PR TITLE
Add tap-to-open functionality and cursor styling for puller-tab

### DIFF
--- a/frontend/components/LocationDrawer.css
+++ b/frontend/components/LocationDrawer.css
@@ -62,6 +62,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
 
 .puller {

--- a/frontend/components/LocationDrawer.jsx
+++ b/frontend/components/LocationDrawer.jsx
@@ -94,7 +94,7 @@ export default function LocationDrawer() {
           },
         }}
       >
-        <div className="puller-tab">
+        <div className="puller-tab" onClick={() => open ? handleClose() : setOpen(true)}>
           <div className="puller" />
         </div>
         <div className="mobile-drawer-inner">


### PR DESCRIPTION
This pull request introduces a minor UI improvement to the `LocationDrawer` component, making the drawer's tab clickable to open or close the drawer, and updating the cursor style to indicate interactivity.

UI/UX improvements:

* Made the `.puller-tab` in `LocationDrawer` clickable to toggle the drawer open or closed by adding an `onClick` handler.
* Updated the `.puller-tab` CSS to show a pointer cursor, indicating it is clickable.