### PR TITLE
Show Route button reflects active/inactive state

### DIFF
--- a/frontend/components/LocationCard.css
+++ b/frontend/components/LocationCard.css
@@ -139,13 +139,23 @@
 
 .btn-show-route {
   background: rgb(252, 245, 228);
-  color: orange
-
+  color: #f97316;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
 }
 
 .btn-show-route:hover {
   background: rgb(253, 238, 204);
+}
 
+/* Active state: route is currently displayed on the map */
+.btn-show-route--active {
+  background: #f97316;
+  color: white;
+  box-shadow: 0 0 0 2px #fdba74;
+}
+
+.btn-show-route--active:hover {
+  background: #ea580c;
 }
 
 .btn-delete {

--- a/frontend/components/LocationCard.jsx
+++ b/frontend/components/LocationCard.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Trash2, Navigation, Star, DollarSign, Sun, Cloud, CloudRain, CloudSnow, CloudDrizzle } from 'lucide-react';
+import { Trash2, Navigation, Star, DollarSign, Sun, Cloud, CloudRain, CloudSnow, CloudDrizzle, Map, MapOff } from 'lucide-react';
 import { formatDurationFromSeconds } from '../utils/time';
 import { getImperialDist } from '../utils/distance';
 import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
@@ -49,7 +49,9 @@ const weatherColors = {
  * @param {{ place: place }} props
  */
 export default function LocationCard({place}) {
-  const { deleteFromHistory, setDestination, toggleActiveRoute } = useMapFeatures();
+  const { deleteFromHistory, setDestination, toggleActiveRoute, activeRoutes } = useMapFeatures();
+  // true when this card's route is currently being displayed on the map
+  const isRouteActive = activeRoutes.some(r => r.placeId === place.destObj.placeId);
   console.log(place)
 
   return (
@@ -105,8 +107,14 @@ export default function LocationCard({place}) {
           <Navigation className="btn-icon" />
           Set Route
         </button>
-        <button className="btn-show-route" onClick={() => {toggleActiveRoute(place.destObj)}}>
-          Show Route
+        <button
+          className={`btn-show-route${isRouteActive ? ' btn-show-route--active' : ''}`}
+          onClick={() => { toggleActiveRoute(place.destObj); }}
+        >
+          {isRouteActive
+            ? <><Map className="btn-icon" /> Route On</>
+            : <><MapOff className="btn-icon" /> Show Route</>
+          }
         </button>
         <button className="btn-delete" onClick={() => {deleteFromHistory(place.desPlaceId)}}>
           <Trash2 className="btn-icon" />


### PR DESCRIPTION
## Summary

- The **Show Route** button on `LocationCard` now toggles between two visual states so users know at a glance whether a route is currently displayed on the map
- **Inactive**: cream/tan background, orange text, `MapOff` icon, label _"Show Route"_
- **Active**: solid orange background (`#f97316`), white text, subtle ring (`box-shadow`), `Map` icon, label _"Route On"_
- State is derived from `activeRoutes` in `MapContext` — no new state introduced

## Files changed

| File | Change |
|---|---|
| `frontend/components/LocationCard.jsx` | Read `activeRoutes` from context; compute `isRouteActive`; conditionally apply `.btn-show-route--active` class and swap icon/label |
| `frontend/components/LocationCard.css` | Added `.btn-show-route--active` and `.btn-show-route--active:hover` rules; added `transition` to base `.btn-show-route` |

## Test plan

- [ ] Add a destination and click **Show Route** — button should turn solid orange with _"Route On"_ label and `Map` icon
- [ ] Click again to toggle off — button should return to cream with _"Show Route"_ label and `MapOff` icon
- [ ] Add multiple destinations and toggle routes independently — each card's button should reflect its own active state
- [ ] Confirm **Set Route** and **Delete** buttons are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)