### PR TITLE
HTTP request foundation: timeout, retry, abort, detailed errors

### DIFF
--- a/frontend/config/maps.js
+++ b/frontend/config/maps.js
@@ -7,20 +7,26 @@ import { PlacesApi } from '../place-api';
  * Fail-fast env validation. Throws at module-load time with a clear, actionable
  * message instead of letting `undefined` keys propagate into API calls and surface
  * as cryptic 400s deep in the call stack.
+ *
+ * IMPORTANT: Next.js inlines `process.env.NEXT_PUBLIC_*` at build time only when
+ * accessed via static literal (e.g. `process.env.NEXT_PUBLIC_FOO`). Dynamic access
+ * like `process.env[name]` is NOT inlined and resolves to undefined in the client
+ * bundle. So requireEnv takes the already-resolved value as an argument.
+ * See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
  */
-function requireEnv(name) {
-  const v = process.env[name];
-  if (!v) {
+function requireEnv(name, value) {
+  if (!value) {
     throw new Error(
       `[config/maps] Missing required env var: ${name}. ` +
-      `Add it to frontend/.env (browser-exposed vars must use the NEXT_PUBLIC_ prefix).`
+      `Add it to frontend/.env (browser-exposed vars must use the NEXT_PUBLIC_ prefix), ` +
+      `then restart the dev server.`
     );
   }
-  return v;
+  return value;
 }
 
-const GOOGLE_MAPS_KEY = requireEnv('NEXT_PUBLIC_GOOGLE_MAPS_KEY');
-const GOOGLE_MAPS_MAP_ID = requireEnv('NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID');
+const GOOGLE_MAPS_KEY = requireEnv('NEXT_PUBLIC_GOOGLE_MAPS_KEY', process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY);
+const GOOGLE_MAPS_MAP_ID = requireEnv('NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID', process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID);
 
 export const MAP_CONFIG = {
   apiKey: GOOGLE_MAPS_KEY,

--- a/frontend/config/maps.js
+++ b/frontend/config/maps.js
@@ -3,10 +3,28 @@ import { RoutesApi } from '../routes-api';
 import { RoutesMatrixAPI } from '../routes-matrix-api';
 import { PlacesApi } from '../place-api';
 
+/**
+ * Fail-fast env validation. Throws at module-load time with a clear, actionable
+ * message instead of letting `undefined` keys propagate into API calls and surface
+ * as cryptic 400s deep in the call stack.
+ */
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(
+      `[config/maps] Missing required env var: ${name}. ` +
+      `Add it to frontend/.env (browser-exposed vars must use the NEXT_PUBLIC_ prefix).`
+    );
+  }
+  return v;
+}
+
+const GOOGLE_MAPS_KEY = requireEnv('NEXT_PUBLIC_GOOGLE_MAPS_KEY');
+const GOOGLE_MAPS_MAP_ID = requireEnv('NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID');
 
 export const MAP_CONFIG = {
-  apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY,
-  mapId: process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID,
+  apiKey: GOOGLE_MAPS_KEY,
+  mapId: GOOGLE_MAPS_MAP_ID,
   mapStyle: { width: "100%", height: "100%" },
   defaultCenter: { lat: 37.7749, lng: -122.4194 },
   defaultZoom: 14,

--- a/frontend/lib/AutoCompleteAPI.js
+++ b/frontend/lib/AutoCompleteAPI.js
@@ -1,24 +1,31 @@
 // lib/PlacesAPI.js
+import { apiRequest } from './apiRequest';
 
 const AUTOCOMPLETE_ENDPOINT = 'https://places.googleapis.com/v1/places:autocomplete';
 const GEOCODE_ENDPOINT = 'https://geocode.googleapis.com/v4beta/geocode/places/';
 
 export class PlacesAPI {
   constructor(apiKey) {
-    if (!apiKey) throw new Error('API key is required');
+    if (!apiKey) throw new Error('PlacesAPI: API key is required');
     this.apiKey = apiKey;
   }
 
   /**
-   * Get place predictions for a text input
+   * Get place predictions for a text input.
+   *
+   * Retry is disabled here: the user is still typing, so a stale retry would
+   * either fight the next keystroke's request or return suggestions for an
+   * outdated query. Better to fail fast and let the next keystroke try fresh.
+   *
    * @param {string} input
+   * @param {{ signal?: AbortSignal }} [requestOptions]
    * @returns {Promise<Array>}
    */
-  async autocomplete(input) {
+  async autocomplete(input, requestOptions = {}) {
     if (!input || input.length < 3) return [];
     const body = { input };
- 
-    const response = await fetch(AUTOCOMPLETE_ENDPOINT, {
+
+    const data = await apiRequest(AUTOCOMPLETE_ENDPOINT, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -26,61 +33,56 @@ export class PlacesAPI {
         'X-Goog-FieldMask': 'suggestions.placePrediction.placeId,suggestions.placePrediction.text.text',
       },
       body: JSON.stringify(body),
+      signal: requestOptions.signal,
+      retry: false,
+      label: 'Autocomplete',
     });
 
-    if (!response.ok) {
-      throw new Error(`Places API error: ${response.status} ${response.statusText}`);
-    }
-
-    const data = await response.json();
     return data.suggestions ?? [];
   }
 
   /**
    * Get lat/lng and address for a place ID
    * @param {string} placeId
+   * @param {string} [fieldMask]
+   * @param {{ signal?: AbortSignal }} [requestOptions]
    */
-  async getGeocodeV4(placeId, fieldMask="location") {
+  async getGeocodeV4(placeId, fieldMask = "location", requestOptions = {}) {
     if(!placeId){
-      throw new Error("PlaceId required");
+      throw new Error("PlacesAPI.getGeocodeV4: placeId is required");
     }
 
-    const response = await fetch(`${GEOCODE_ENDPOINT}/${encodeURIComponent(placeId)}`, {
+    return apiRequest(`${GEOCODE_ENDPOINT}/${encodeURIComponent(placeId)}`, {
       method: 'GET',
       headers: {
         "X-Goog-Api-Key": this.apiKey,
         "X-Goog-FieldMask": fieldMask,
       },
+      signal: requestOptions.signal,
+      label: 'GeocodeV4',
     });
-
-    if (!response.ok) {
-      throw new Error(`Gecode API error (faile to fetch the lat and long based on PlaceId): ${response.status} ${response.statusText}`);
-    }
-
-    return response.json();
   }
 
-  async getGeocodeV3(placeId) {
+  async getGeocodeV3(placeId, requestOptions = {}) {
     // TODO: special case because gecode api can't have browser restrictions
     const apiKey = process.env.NEXT_PUBLIC_GOOGLE_GEOCODING_API_KEY
-    
-    if (!placeId) throw new Error('placeId required');
-  
+
+    if (!placeId) throw new Error('PlacesAPI.getGeocodeV3: placeId is required');
+    if (!apiKey) throw new Error('PlacesAPI.getGeocodeV3: NEXT_PUBLIC_GOOGLE_GEOCODING_API_KEY is required');
+
     const url = `https://maps.googleapis.com/maps/api/geocode/json?place_id=${encodeURIComponent(placeId)}&key=${apiKey}`;
-  
-    const response = await fetch(url);
-  
-    if (!response.ok) {
-      throw new Error(`Geocode error: ${response.status} ${response.statusText}`);
-    }
-  
-    const data = await response.json();
+
+    const data = await apiRequest(url, {
+      method: 'GET',
+      signal: requestOptions.signal,
+      label: 'GeocodeV3',
+    });
+
     console.log('Geocode raw response:', data);
 
     const loc = data.results?.[0]?.geometry?.location;
-  
     if (!loc) throw new Error('No geocode results for placeId: ' + placeId);
-  
+
     return { location: { latitude: loc.lat, longitude: loc.lng } };
   }
 }

--- a/frontend/lib/apiError.js
+++ b/frontend/lib/apiError.js
@@ -1,0 +1,69 @@
+/**
+ * Detailed error class for HTTP requests so failures are easy to trace in the console.
+ *
+ * Carries:
+ *   - status / statusText  → HTTP response status
+ *   - code                 → 'TIMEOUT' | 'NETWORK' | 'PARSE' | 'ABORT' | http status number
+ *   - endpoint / method    → URL and verb of the request
+ *   - googleStatus         → Google's `error.status` field (e.g. 'INVALID_ARGUMENT', 'PERMISSION_DENIED')
+ *   - googleMessage        → Google's `error.message` field — usually the most actionable detail
+ *   - googleDetails        → Google's `error.details` array (field violations, links, etc.)
+ *   - attempt              → which retry attempt failed (1-indexed)
+ *   - label                → short tag for the call site (e.g. 'RoutesMatrix')
+ */
+export class ApiError extends Error {
+  constructor({
+    message,
+    status,
+    statusText,
+    code,
+    endpoint,
+    method,
+    googleStatus,
+    googleMessage,
+    googleDetails,
+    attempt,
+    label,
+    cause,
+  }) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.statusText = statusText;
+    this.code = code;
+    this.endpoint = endpoint;
+    this.method = method;
+    this.googleStatus = googleStatus;
+    this.googleMessage = googleMessage;
+    this.googleDetails = googleDetails;
+    this.attempt = attempt;
+    this.label = label;
+    if (cause) this.cause = cause;
+  }
+
+  /**
+   * Compact object suitable for `console.error` / structured logging.
+   * `Error` itself stringifies to just the message; this surfaces all fields.
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      label: this.label,
+      message: this.message,
+      code: this.code,
+      status: this.status,
+      statusText: this.statusText,
+      endpoint: this.endpoint,
+      method: this.method,
+      googleStatus: this.googleStatus,
+      googleMessage: this.googleMessage,
+      googleDetails: this.googleDetails,
+      attempt: this.attempt,
+    };
+  }
+}
+
+/** True for HTTP statuses worth retrying (transient server errors + rate limits). */
+export function isRetryableStatus(status) {
+  return status === 429 || (status >= 500 && status < 600);
+}

--- a/frontend/lib/apiRequest.js
+++ b/frontend/lib/apiRequest.js
@@ -1,0 +1,187 @@
+import { ApiError, isRetryableStatus } from './apiError';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+/** Exponential backoff with jitter: 200ms, 400ms, 800ms (+ up to 100ms jitter). */
+function backoffMs(attempt) {
+  return 200 * 2 ** (attempt - 1) + Math.random() * 100;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Best-effort parse of Google API error envelope:
+ *   { error: { code, message, status, details } }
+ */
+async function parseGoogleError(response) {
+  try {
+    const body = await response.json();
+    const err = body?.error;
+    if (!err) return {};
+    return {
+      code: err.code,
+      googleStatus: err.status,
+      googleMessage: err.message,
+      googleDetails: err.details,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Centralized fetch wrapper for all Google Maps API calls.
+ *
+ * Features:
+ *  - per-attempt timeout via internal AbortController (default 10s)
+ *  - external AbortSignal support (for stale-request cancellation in hooks/components)
+ *  - exponential backoff retry on 429 / 5xx / network / timeout (default 3 attempts)
+ *  - honors Retry-After header for 429
+ *  - parses Google's JSON error envelope into ApiError fields
+ *  - distinguishes user-initiated abort vs internal timeout
+ *
+ * @param {string|URL} url
+ * @param {object} options
+ * @param {string} [options.method='GET']
+ * @param {object} [options.headers]
+ * @param {string} [options.body]
+ * @param {AbortSignal} [options.signal]            external signal (caller-controlled cancel)
+ * @param {number} [options.timeoutMs=10000]        per-attempt timeout
+ * @param {number} [options.maxAttempts=3]          total attempts including the first
+ * @param {boolean} [options.retry=true]            set to false for non-retryable endpoints (e.g. autocomplete)
+ * @param {string} [options.label]                  short tag for logs/errors
+ * @returns {Promise<any>} parsed JSON body
+ * @throws {ApiError}
+ */
+export async function apiRequest(url, options = {}) {
+  const {
+    method = 'GET',
+    headers,
+    body,
+    signal: externalSignal,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    retry = true,
+    label,
+  } = options;
+
+  const endpoint = url.toString();
+  const totalAttempts = retry ? maxAttempts : 1;
+  let lastError;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    // Internal controller for timeout. We chain externalSignal → controller so a single
+    // controller.signal carries both timeout aborts and caller-initiated aborts.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException(`Timed out after ${timeoutMs}ms`, 'TimeoutError'));
+    }, timeoutMs);
+
+    const onExternalAbort = () => controller.abort(externalSignal.reason);
+    if (externalSignal) {
+      if (externalSignal.aborted) controller.abort(externalSignal.reason);
+      else externalSignal.addEventListener('abort', onExternalAbort);
+    }
+
+    try {
+      const response = await fetch(endpoint, { method, headers, body, signal: controller.signal });
+
+      if (!response.ok) {
+        const googleErr = await parseGoogleError(response);
+        const err = new ApiError({
+          message: `${label ?? 'API'} failed: ${response.status} ${response.statusText}`,
+          status: response.status,
+          statusText: response.statusText,
+          endpoint,
+          method,
+          attempt,
+          label,
+          ...googleErr,
+        });
+
+        if (retry && isRetryableStatus(response.status) && attempt < totalAttempts) {
+          // 429: respect Retry-After if present, otherwise use backoff
+          let delay = backoffMs(attempt);
+          if (response.status === 429) {
+            const retryAfter = response.headers.get('Retry-After');
+            const seconds = retryAfter ? parseInt(retryAfter, 10) : NaN;
+            if (!Number.isNaN(seconds)) delay = Math.max(delay, seconds * 1000);
+          }
+          lastError = err;
+          await sleep(delay);
+          continue;
+        }
+
+        throw err;
+      }
+
+      // Parse JSON in a guarded block so malformed bodies surface as PARSE errors
+      try {
+        return await response.json();
+      } catch (parseErr) {
+        throw new ApiError({
+          message: `${label ?? 'API'} response was not valid JSON: ${parseErr.message}`,
+          code: 'PARSE',
+          status: response.status,
+          endpoint,
+          method,
+          attempt,
+          label,
+          cause: parseErr,
+        });
+      }
+    } catch (err) {
+      // The internal controller fires AbortError for both timeouts and external aborts.
+      // We tell them apart by checking the externalSignal — if it's aborted, the caller did it.
+      if (err.name === 'AbortError' || err.name === 'TimeoutError') {
+        if (externalSignal?.aborted) {
+          // Caller cancelled (e.g. deps changed) — propagate as-is, do not retry
+          throw err;
+        }
+        // Our timeout fired
+        const timeoutErr = new ApiError({
+          message: `${label ?? 'API'} timed out after ${timeoutMs}ms`,
+          code: 'TIMEOUT',
+          endpoint,
+          method,
+          attempt,
+          label,
+          cause: err,
+        });
+        if (retry && attempt < totalAttempts) {
+          lastError = timeoutErr;
+          await sleep(backoffMs(attempt));
+          continue;
+        }
+        throw timeoutErr;
+      }
+
+      // Already an ApiError from the !response.ok branch — re-throw without re-wrapping
+      if (err instanceof ApiError) throw err;
+
+      // Network failure (DNS, offline, CORS reject) — fetch itself rejected
+      const networkErr = new ApiError({
+        message: `${label ?? 'API'} network error: ${err.message}`,
+        code: 'NETWORK',
+        endpoint,
+        method,
+        attempt,
+        label,
+        cause: err,
+      });
+      if (retry && attempt < totalAttempts) {
+        lastError = networkErr;
+        await sleep(backoffMs(attempt));
+        continue;
+      }
+      throw networkErr;
+    } finally {
+      clearTimeout(timeoutId);
+      if (externalSignal) externalSignal.removeEventListener('abort', onExternalAbort);
+    }
+  }
+
+  // Unreachable, but satisfies static analysis
+  throw lastError;
+}

--- a/frontend/lib/logger.js
+++ b/frontend/lib/logger.js
@@ -1,0 +1,23 @@
+import { ApiError } from './apiError';
+
+/**
+ * Single chokepoint for error logging.
+ * Console-only today; swap in Sentry / analytics here later without touching call sites.
+ *
+ * @param {unknown} err
+ * @param {object} [context] - extra fields to attach (e.g. { hook: 'useDestinations', home, dest })
+ */
+export function logError(err, context = {}) {
+  if (err instanceof ApiError) {
+    // toJSON() flattens all fields; spreading keeps them at the top level so they're easy to scan
+    console.error('[API ERROR]', { ...err.toJSON(), ...context });
+    return;
+  }
+
+  if (err?.name === 'AbortError') {
+    console.warn('[API ABORT]', { reason: err.message, ...context });
+    return;
+  }
+
+  console.error('[ERROR]', err, context);
+}

--- a/frontend/place-api.js
+++ b/frontend/place-api.js
@@ -1,3 +1,5 @@
+import { apiRequest } from './lib/apiRequest';
+
 const PLACES_API_ENDPOINT = "https://places.googleapis.com/v1/places";
 
 /**
@@ -17,12 +19,12 @@ const PLACES_API_ENDPOINT = "https://places.googleapis.com/v1/places";
 
 export class PlacesApi {
   constructor(apiKey){
-    if (!apiKey) throw new Error("API key is needed")
+    if (!apiKey) throw new Error("PlacesApi: API key is required")
     this.apiKey = apiKey;
   }
 
   /**
-   * get details on a place 
+   * get details on a place
    * adjust fildmask args as needed
    * reference:
    * for request structure
@@ -31,25 +33,22 @@ export class PlacesApi {
    * https://developers.google.com/maps/documentation/places/web-service/reference/rest/v1/places#PriceLevel
    * @param {string} placeId the unique id key representing a place
    * @param {string} [fieldMask] the field mask for the response data
+   * @param {{ signal?: AbortSignal }} [requestOptions]
    * @returns {Promise<PlaceDetails>}
    */
-  async getPlaceDetails(placeId, fieldMask = "rating,regularOpeningHours,priceLevel,id"){
+  async getPlaceDetails(placeId, fieldMask = "rating,regularOpeningHours,priceLevel,id", requestOptions = {}){
     if(!placeId){
-      throw new Error("PlaceId required");
+      throw new Error("PlacesApi.getPlaceDetails: placeId is required");
     }
 
-    const response = await fetch(`${PLACES_API_ENDPOINT}/${encodeURIComponent(placeId)}`, {
+    return apiRequest(`${PLACES_API_ENDPOINT}/${encodeURIComponent(placeId)}`, {
       method: 'GET',
       headers: {
         "X-Goog-Api-Key": this.apiKey,
         "X-Goog-FieldMask": fieldMask,
       },
+      signal: requestOptions.signal,
+      label: 'PlaceDetails',
     });
-
-    if (!response.ok) {
-      throw new Error(`Places API error: ${response.status} ${response.statusText}`);
-    }
-
-    return response.json();
   }
 }

--- a/frontend/routes-api.ts
+++ b/frontend/routes-api.ts
@@ -1,4 +1,6 @@
 /// <reference types="@types/google.maps" />
+import { apiRequest } from './lib/apiRequest';
+
 const fields = ['routes.viewport', 'routes.legs', 'routes.polylineDetails', 'routes.legs.duration', 'routes.legs.distanceMeters'];
 
 // docs at https://developers.google.com/maps/documentation/routes/reference/rest/v2/TopLevel/computeRoutes
@@ -10,14 +12,20 @@ export class RoutesApi {
   private readonly apiKey: string;
 
   constructor(apiKey: string) {
+    if (!apiKey) throw new Error('RoutesApi: API key is required');
     this.apiKey = apiKey;
   }
 
   async computeRoutes(
     from: google.maps.LatLngLiteral,
     to: google.maps.LatLngLiteral,
-    options: any
+    options: any,
+    requestOptions?: { signal?: AbortSignal }
   ) {
+    if (!from || !to) {
+      throw new Error('RoutesApi.computeRoutes: origin and destination are required');
+    }
+
     const routeRequest = {
       origin: {
         location: {latLng: {longitude: from.lng, latitude: from.lat}}
@@ -31,21 +39,15 @@ export class RoutesApi {
     const url = new URL(ROUTES_API_ENDPOINT);
     url.searchParams.set('fields', fields.join(','));
 
-    const response = await fetch(url, {
+    return apiRequest(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Goog-Api-Key': this.apiKey
+        'X-Goog-Api-Key': this.apiKey,
       },
-      body: JSON.stringify(routeRequest)
+      body: JSON.stringify(routeRequest),
+      signal: requestOptions?.signal,
+      label: 'Routes',
     });
-
-    if (!response.ok) {
-      throw new Error(
-        `Request failed with status: ${response.status} - ${response.statusText}`
-      );
-    }
-
-    return await response.json();
   }
 }

--- a/frontend/routes-matrix-api.js
+++ b/frontend/routes-matrix-api.js
@@ -1,6 +1,6 @@
+import { apiRequest } from './lib/apiRequest';
 
-
-// options for request: 
+// options for request:
 // https://developers.google.com/maps/documentation/routes/reference/rest/v2/TopLevel/computeRouteMatrix
 
 const ROUTES_MATRIX_API_ENDPOINT =
@@ -8,7 +8,7 @@ const ROUTES_MATRIX_API_ENDPOINT =
 
 export class RoutesMatrixAPI {
   constructor(apiKey){
-    if (!apiKey) throw new Error("API key is needed")
+    if (!apiKey) throw new Error("RoutesMatrixAPI: API key is required")
     this.apiKey = apiKey;
   }
 
@@ -17,11 +17,12 @@ export class RoutesMatrixAPI {
    * @param {{lat:number, lng:number}} from
    * @param {Array<{lat:number, lng:number}>} to
    * @param {"DRIVE"|"WALK"|"TRANSIT"} travelMode
+   * @param {{ signal?: AbortSignal }} [requestOptions]
    * @returns {Promise<Array<{destinationIndex:number, duration:number, distance:number}>>}
    */
-  async computeMatrix(from, to, travelMode = "DRIVE"){
+  async computeMatrix(from, to, travelMode = "DRIVE", requestOptions = {}){
     if (!from || !to || to.length === 0) {
-      throw new Error("Origin and at least one destination are required");
+      throw new Error("RoutesMatrixAPI.computeMatrix: origin and at least one destination are required");
     }
 
     const body = {
@@ -37,7 +38,7 @@ export class RoutesMatrixAPI {
           }
         },
       ],
-    
+
       destinations: to.map(destination => ({
         waypoint: {
           location: {
@@ -52,7 +53,7 @@ export class RoutesMatrixAPI {
       travelMode,
     }
 
-    const response = await fetch(ROUTES_MATRIX_API_ENDPOINT, {
+    return apiRequest(ROUTES_MATRIX_API_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -60,12 +61,8 @@ export class RoutesMatrixAPI {
         "X-Goog-FieldMask": "originIndex,destinationIndex,duration,distanceMeters,condition",
       },
       body: JSON.stringify(body),
+      signal: requestOptions.signal,
+      label: `RoutesMatrix:${travelMode}`,
     });
-
-    if (!response.ok) {
-      throw new Error(`Routes MATRIX API error: ${response.status} ${response.statusText}`);
-    }
-    
-    return response.json();
   }
 }


### PR DESCRIPTION
## Summary

Foundation for robust HTTP request handling across all four Google Maps API clients. Adds a single shared `apiRequest()` wrapper, a detailed `ApiError` class, and a `logError()` chokepoint. No consumer changes yet — that's the next stacked branch.

## What's in this branch

### New files

- **`frontend/lib/apiError.js`** — `ApiError` class carrying `status`, `code`, `endpoint`, `method`, `googleStatus`, `googleMessage`, `googleDetails`, `attempt`, and `label`. `toJSON()` flattens all fields so `console.error` shows everything at a glance instead of just the `.message` string.
- **`frontend/lib/apiRequest.js`** — Shared fetch wrapper with:
  - 10s per-attempt timeout via internal `AbortController`
  - 3-attempt exponential backoff (200 / 400 / 800 ms + jitter)
  - Retries on 429 / 5xx / network / timeout
  - Honors `Retry-After` header for 429
  - External `AbortSignal` threading so callers can cancel stale requests
  - Parses Google's JSON error envelope (`{ error: { code, status, message, details } }`)
  - Distinguishes user-initiated abort from internal timeout
  - Wraps `response.json()` parse failures as `code: 'PARSE'` errors
- **`frontend/lib/logger.js`** — `logError(err, context)` chokepoint. Console-only today; one swap point to add Sentry / analytics later.

### Modified files

- **`frontend/config/maps.js`** — Fail-fast env validation. `NEXT_PUBLIC_GOOGLE_MAPS_KEY` and `NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID` now throw at module-load with an actionable message instead of producing cryptic 400s deep in the call stack.
- **`frontend/routes-api.ts`** — Uses `apiRequest`, accepts optional `{ signal }`.
- **`frontend/routes-matrix-api.js`** — Same.
- **`frontend/place-api.js`** — Same.
- **`frontend/lib/AutoCompleteAPI.js`** — Same, but `autocomplete()` opts out of retry (`retry: false`) because the user is still typing — a stale retry would fight the next keystroke.

## Decisions worth flagging

- **Console logging only** per request. `logError()` is structured so you can swap in Sentry without touching any of the four clients.
- **Autocomplete is the only no-retry endpoint.** Other failures retry up to 3 times; autocomplete fails fast since the next keystroke supersedes it anyway.
- **`route.tsx` not updated** because it's planned for retirement per `docs/route-unification.md`.
- **Backward-compatible signatures.** Every client method's existing positional arguments still work; the new `{ signal }` is an optional trailing object.

## Test plan

- [ ] `npm --prefix frontend run dev` boots without errors
- [ ] Set an origin + destination, confirm matrix data loads
- [ ] Highlight a route, confirm polyline draws
- [ ] In DevTools, throttle network to "Offline" and confirm errors print with full `[API ERROR]` shape (endpoint, status, googleMessage, attempt)
- [ ] Remove `NEXT_PUBLIC_GOOGLE_MAPS_KEY` from `.env`, confirm app fails fast at module-load with the actionable message

## Follow-up branch

`feature/consumer-error-handling` (stacked on this one) updates `useDestinations` and `useRouteCache` to thread `AbortController` for stale-request cancellation and route errors through `logError`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)