### PR TITLE
Wire hooks into error foundation: stale-request cancellation + structured logging

### DIFF
--- a/frontend/hooks/useDestinations.js
+++ b/frontend/hooks/useDestinations.js
@@ -1,17 +1,18 @@
 import { useState, useEffect, useRef } from 'react';
 import { createDataLookup, prepRowData } from '../utils/places';
 import { routesMatrixApi, placesApi } from '../config/maps';
+import { logError } from '../lib/logger';
 
 // TODO: 3/20 think about a simple cache garabage collection strategy
 
 // Helper 1: Fetches only missing place details and mutates the cache object
-async function fetchMissingPlaces(missingDests, cacheRef) {
+async function fetchMissingPlaces(missingDests, cacheRef, signal) {
   if (missingDests.length === 0) return;
-  
+
   const results = await Promise.all(
-    missingDests.map(dest => placesApi.getPlaceDetails(dest.placeId))
+    missingDests.map(dest => placesApi.getPlaceDetails(dest.placeId, undefined, { signal }))
   );
-  
+
   // Write the results ot the cache
   results.forEach((res, i) => {
     cacheRef.current.places[missingDests[i].placeId] = res;
@@ -21,16 +22,16 @@ async function fetchMissingPlaces(missingDests, cacheRef) {
 }
 
 // Helper 2: Fetches only missing routes for the current home and mutates the cache object
-async function fetchMissingRoutes(home, missingDests, cacheRef) {
+async function fetchMissingRoutes(home, missingDests, cacheRef, signal) {
   if (missingDests.length === 0) return;
-  
+
   const [driveRes, walkRes, transitRes] = await Promise.all([
-    routesMatrixApi.computeMatrix(home, missingDests, "DRIVE"),
-    routesMatrixApi.computeMatrix(home, missingDests, "WALK"),
-    routesMatrixApi.computeMatrix(home, missingDests, "TRANSIT")
+    routesMatrixApi.computeMatrix(home, missingDests, "DRIVE", { signal }),
+    routesMatrixApi.computeMatrix(home, missingDests, "WALK", { signal }),
+    routesMatrixApi.computeMatrix(home, missingDests, "TRANSIT", { signal })
   ]);
-  
-  // this has to happen because the reurn of the matrix is in random order so we have 
+
+  // this has to happen because the reurn of the matrix is in random order so we have
   // recreate it as a object we can view by key
   const driveLookUp = createDataLookup(driveRes);
   const walkLookUp = createDataLookup(walkRes);
@@ -70,12 +71,16 @@ export function useDestinations(home, destinations) {
   });
 
   useEffect(() => {
-    let isMounted = true;
+    // AbortController scoped to this effect run. If the user changes home or
+    // destinations while a fetch is in flight, the cleanup below aborts those
+    // requests so their results can't overwrite fresher data later.
+    const controller = new AbortController();
+    const { signal } = controller;
 
     const loadTableData = async () => {
       try {
         if (!home || destinations.length === 0) {
-          if (isMounted) setRows([]);
+          setRows([]);
           return;
         }
 
@@ -84,58 +89,65 @@ export function useDestinations(home, destinations) {
 
         // If after filtering there are no destinations left, clear the table
         if (filteredDests.length === 0) {
-          if (isMounted) setRows([]);
+          setRows([]);
           return;
         }
 
         const currentHomeId = home.placeId;
         // 1. Identify what data is currently missing from our caches
-        
+
         // places cache i.e. ratings and price
         const missingPlaces = filteredDests.filter(
           d => !cache.current.places[d.placeId]
         );
-        
-        // routes cache i.e distance and time 
+
+        // routes cache i.e distance and time
         const missingRoutes = filteredDests.filter(
           d => !cache.current.routes[`${currentHomeId}_${d.placeId}`]
         );
 
         // 2. Fetch only the missing pieces concurrently
         await Promise.all([
-          fetchMissingPlaces(missingPlaces, cache),
-          fetchMissingRoutes(home, missingRoutes, cache)
+          fetchMissingPlaces(missingPlaces, cache, signal),
+          fetchMissingRoutes(home, missingRoutes, cache, signal)
         ]);
 
+        // If the effect was cleaned up while we were awaiting, drop the result
+        if (signal.aborted) return;
+
         // 3. Assemble the rows entirely from the local cache
-        if (isMounted) {
-          const newRows = filteredDests.map(dest => {
-            // read the cahce here 
-            const placeData = cache.current.places[dest.placeId];
-            const routeData = cache.current.routes[`${currentHomeId}_${dest.placeId}`];
-            
-            console.log(dest);
+        const newRows = filteredDests.map(dest => {
+          // read the cahce here
+          const placeData = cache.current.places[dest.placeId];
+          const routeData = cache.current.routes[`${currentHomeId}_${dest.placeId}`];
 
-            return prepRowData(
-              dest,
-              routeData.drive,
-              routeData.walk,
-              routeData.transit,
-              placeData
-            );
-          });
+          console.log(dest);
 
-          setRows(newRows);
-        }
+          return prepRowData(
+            dest,
+            routeData.drive,
+            routeData.walk,
+            routeData.transit,
+            placeData
+          );
+        });
+
+        setRows(newRows);
       } catch (err) {
-        console.error("Destination initialization failed:", err);
+        // AbortError is expected when deps change mid-flight — don't surface it as a failure
+        if (signal.aborted || err?.name === 'AbortError') return;
+        logError(err, {
+          hook: 'useDestinations',
+          homeId: home?.placeId,
+          destCount: destinations?.length,
+        });
       }
     };
 
     loadTableData();
 
     return () => {
-      isMounted = false;
+      controller.abort();
     };
   }, [home, destinations]); // The effect now runs anytime home or dests change, but only fetches if cache is empty
 

--- a/frontend/hooks/useRouteCache.js
+++ b/frontend/hooks/useRouteCache.js
@@ -1,26 +1,20 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { routesApiClient } from '../config/maps';
 import { useMapFeatures } from '../context/MapContext';
+import { logError } from '../lib/logger';
 
-async function fetchMissingRoute(home, dest, routeOptions) {
-  try {
-    // 1. Declare with 'const' to keep it local
-    const res = await routesApiClient.computeRoutes(home, dest, routeOptions);
+async function fetchMissingRoute(home, dest, routeOptions, signal) {
+  const res = await routesApiClient.computeRoutes(home, dest, routeOptions, { signal });
 
-    // 2. Check if routes actually exist before unboxing
-    if (!res.routes || res.routes.length === 0) {
-      console.warn("No routes found for:", dest.placeId);
-      return null; 
-    }
-
-    const [route] = res.routes; // get the first route
-    return route;
-
-  } catch (error) {
-    // 3. Handle network/API errors gracefully
-    console.error("Maps API Error:", error);
-    return null; 
+  // Empty `routes` array means Google found no path — this is not an error,
+  // just an unservable request (e.g. transit between disconnected regions)
+  if (!res.routes || res.routes.length === 0) {
+    console.warn("No routes found for:", dest.placeId);
+    return null;
   }
+
+  const [route] = res.routes;
+  return route;
 }
 
 export function useRouteCache(destination, routeOptions) {
@@ -28,23 +22,38 @@ export function useRouteCache(destination, routeOptions) {
   const [route, setRoute] = useState(null);
 
   useEffect(() => {
-    if (!home || !destination) return;  // missing this
+    if (!home || !destination) return;
 
     const routeKey = `${home.placeId}_${destination.placeId}`;
     const cachedRoute = routesCache.current[routeKey];
 
-    if (cachedRoute){
+    if (cachedRoute) {
       setRoute(cachedRoute);
       return;
     }
 
-    fetchMissingRoute(home, destination, routeOptions).then(fetchedRoute => {
-      if (!fetchedRoute) return;
-      routesCache.current[routeKey] = fetchedRoute;
-      setRoute(fetchedRoute);
-    });
+    // Abort any in-flight request if home / destination / options change before it resolves
+    const controller = new AbortController();
 
-  }, [home, destination, routeOptions]) 
+    fetchMissingRoute(home, destination, routeOptions, controller.signal)
+      .then(fetchedRoute => {
+        if (controller.signal.aborted || !fetchedRoute) return;
+        routesCache.current[routeKey] = fetchedRoute;
+        setRoute(fetchedRoute);
+      })
+      .catch(err => {
+        if (controller.signal.aborted || err?.name === 'AbortError') return;
+        logError(err, {
+          hook: 'useRouteCache',
+          homeId: home?.placeId,
+          destId: destination?.placeId,
+        });
+      });
 
-  return {route};
+    return () => {
+      controller.abort();
+    };
+  }, [home, destination, routeOptions, routesCache])
+
+  return { route };
 }


### PR DESCRIPTION
## Summary

Stacked on [#5](https://github.com/bryan13er/whats_close/pull/5). Updates the two consumer hooks to use the foundation: per-effect `AbortController` for stale-request cancellation, and `logError()` for structured logging instead of swallowed `console.error`.

> **Review note:** This PR's diff base is \`feature/api-error-foundation\`, not \`main\`. Review #5 first, then this. After both are approved, merge #5 → main, then retarget this PR to main and merge.

## What changes

### `useDestinations.js`

- **AbortController per effect run.** When `home` or `destinations` change, the cleanup aborts any in-flight matrix or places fetches. Previously an \`isMounted\` flag prevented stale state writes, but didn't actually stop the network calls — wasted bandwidth and wasted quota.
- **Signal threaded through all four calls** (drive/walk/transit matrix + place details).
- **AbortError suppressed in catch** — it's an expected cleanup signal, not a failure.
- **Real errors go through \`logError\`** with hook name and home/dest IDs as context.

### \`useRouteCache.js\`

- AbortController scoped to the effect cancels stale polyline fetches.
- Removed the swallow-and-return-\`null\` catch. Errors now surface through \`logError\` so failed polyline fetches are visible in the console with full context.
- Empty \`routes\` array (Google found no path) still returns null silently — that's an unservable request, not an error.

## Behavior changes a reviewer should know

- **No more zombie requests.** Type a new origin while a matrix call is in flight → the old call is aborted instead of completing and being thrown away by the \`isMounted\` flag.
- **Console output on failure.** Previously \`useRouteCache\` errors were caught and swallowed (only the warn for \"no routes found\" surfaced). Real API failures now show up as \`[API ERROR]\` with full detail.

## Test plan

- [ ] \`npm --prefix frontend run dev\` boots fine
- [ ] Set origin → set destination → confirm matrix loads, polyline draws
- [ ] Rapidly change origin while previous fetch is loading → confirm no stale data lands in the table (network tab should show old requests cancelled)
- [ ] In DevTools throttle to \"Offline\", trigger a fetch, confirm \`[API ERROR]\` prints with \`hook: 'useDestinations'\`, \`status\`, \`googleMessage\`, \`attempt\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)