### PR TITLE
Add JSDoc type definitions for shared shapes

### DIFF
--- a/frontend/components/LocationCard.jsx
+++ b/frontend/components/LocationCard.jsx
@@ -29,25 +29,11 @@ const weatherColors = {
 };
 
 /**
- * @typedef {Object} place
- * @property {string} name - "Chipotle Mexican Grill, Munras Avenue, Monterey, CA, USA"
- * @property {string} desPlaceId - "ChIJl28xQCTkjYAR48CoQtJ6pb4"
- * @property {object} destObj
- * @property {string} destObj.field - "dest"
- * @property {string} destObj.label - "Chipotle Mexican Grill, Munras Avenue, Monterey, CA, USA"
- * @property {string} destObj.placeId - "ChIJl28xQCTkjYAR48CoQtJ6pb4"
- * @property {number} destObj.lat - 36.5969267
- * @property {number} destObj.lng - -121.8944817
- * @property {number} distance - 30353 (meters)
- * @property {number} driveTime - 1595 (seconds)
- * @property {number} transitTime - 3471 (seconds)
- * @property {number} walkTime - 23688 (seconds)
- * @property {number} ratings - 3.8 or 'N/A'
- * @property {string} cost - "$" or 'N/A'
+ * @typedef {import('../types').Row} Row
  */
 
 /**
- * @param {{ place: place }} props
+ * @param {{ place: Row }} props
  */
 export default function LocationCard({place}) {
   const { deleteFromHistory, setDestination, toggleActiveRoute, activeRoutes } = useMapFeatures();

--- a/frontend/components/RouteEntry.jsx
+++ b/frontend/components/RouteEntry.jsx
@@ -7,6 +7,10 @@ import {
   AdvancedMarker,
 } from '@vis.gl/react-google-maps';
 
+/**
+ * @typedef {import('../types').Place} Place
+ * @typedef {import('../types').RouteOptions} RouteOptions
+ */
 
 const defaultAppearance = {
   walkingPolylineColor: '#1E90FF',  // Dodger Blue for walking
@@ -17,6 +21,14 @@ const defaultAppearance = {
 
 };
 
+/**
+ * Renders a single route's polyline + destination marker.
+ *
+ * @param {Object} props
+ * @param {Place} props.destination
+ * @param {number} props.index               - position in `activeRoutes`; used to pick a color from `defaultColors`
+ * @param {RouteOptions} props.routeOptions
+ */
 export default function RouteEntry({destination, index:routeIndex, routeOptions}) {
   const { home } = useMapFeatures();
   const { route } = useRouteCache(destination, routeOptions)

--- a/frontend/context/MapContext.js
+++ b/frontend/context/MapContext.js
@@ -5,16 +5,54 @@ import React, { createContext, useContext, useState, useCallback, useMemo, useRe
 import { MAP_CONFIG } from '../config/maps';
 import { useDestinations } from '../hooks/useDestinations';
 
-/* Shape of 'home' / 'destination' objects:
-  {
-    field:   string, // 'origin' | 'destination'
-    label:   string, // name of place, i.e. full address
-    placeId: string, // 'ChIJ4-Rmg...'
-    lat:     number, // 36.618...
-    lng:     number  // -121.901...
-  }
-*/
+/**
+ * @typedef {import('../types').Place} Place
+ * @typedef {import('../types').Row} Row
+ * @typedef {import('../types').GoogleRoute} GoogleRoute
+ */
 
+/**
+ * @typedef {Object} MapFeatures
+ * The full surface of state and actions exposed by `useMapFeatures()`.
+ * Every component that calls the hook gets this object.
+ *
+ * @property {Place|null}                          home                   - origin / "where from"
+ * @property {(loc: Place) => void}                handleHomeSelect       - sets home + recenters map
+ * @property {() => void}                          handleHomeClear        - clears home, destination, route bounds
+ *
+ * @property {Place|null}                          destination            - active route (Set Route target)
+ * @property {(loc: Place|null) => void}           setDestination
+ * @property {(loc: Place) => void}                addDestination         - sets destination + appends to destHistory if new
+ * @property {() => void}                          clearRoute             - clears destination + route bounds, recenters on home
+ *
+ * @property {Place[]}                             destHistory            - all searched destinations (drives drawer + table)
+ * @property {(placeId: string) => void}           deleteFromHistory      - removes from destHistory + activeRoutes
+ * @property {(history: Place[]) => void}          setDestHistory
+ *
+ * @property {Place[]}                             activeRoutes           - destinations currently drawn as polylines
+ * @property {(loc: Place) => void}                toggleActiveRoute      - add/remove a route from the map
+ *
+ * @property {{north: number, south: number, east: number, west: number}|null} routeBounds
+ * @property {(b: any) => void}                    setRouteBounds
+ *
+ * @property {React.MutableRefObject<Object<string, GoogleRoute>>} routesCache - polyline cache, key = `${homeId}_${destId}`
+ *
+ * @property {{lat: number, lng: number}}          mapCenter
+ * @property {(c: {lat: number, lng: number}) => void} setMapCenter
+ *
+ * @property {boolean}                             isStreetViewVisible
+ * @property {(v: boolean) => void}                setIsStreetViewVisible
+ *
+ * @property {boolean}                             mapType                - true = roadmap, false = hybrid
+ * @property {() => void}                          toggleMapType
+ *
+ * @property {boolean}                             showDataTable
+ * @property {(v: boolean) => void}                setShowDataTable
+ *
+ * @property {Row[]}                               rows                   - prepared data for table/cards (built by useDestinations)
+ */
+
+/** @type {React.Context<MapFeatures|null>} */
 const MapContext = createContext(null);
 
 export function MapFeatureProvider({ children }) {
@@ -144,4 +182,8 @@ export function MapFeatureProvider({ children }) {
   return <MapContext.Provider value={value}>{children}</MapContext.Provider>;
 }
 
+/**
+ * Access global map/route state. See the `MapFeatures` typedef above for the full shape.
+ * @returns {MapFeatures}
+ */
 export const useMapFeatures = () => useContext(MapContext);

--- a/frontend/hooks/useDestinations.js
+++ b/frontend/hooks/useDestinations.js
@@ -2,6 +2,21 @@ import { useState, useEffect, useRef } from 'react';
 import { createDataLookup, prepRowData } from '../utils/places';
 import { routesMatrixApi, placesApi } from '../config/maps';
 
+/**
+ * @typedef {import('../types').Place} Place
+ * @typedef {import('../types').Row} Row
+ * @typedef {import('../types').PlaceDetails} PlaceDetails
+ * @typedef {import('../types').MatrixCell} MatrixCell
+ */
+
+/**
+ * @typedef {Object} DestinationsCache
+ * Internal cache shared across calls within one provider lifetime.
+ *
+ * @property {Object<string, PlaceDetails>} places                                 - keyed by placeId
+ * @property {Object<string, {drive: MatrixCell, walk: MatrixCell, transit: MatrixCell}>} routes - keyed by `${homeId}_${destId}`
+ */
+
 // TODO: 3/20 think about a simple cache garabage collection strategy
 
 // Helper 1: Fetches only missing place details and mutates the cache object
@@ -60,6 +75,15 @@ async function fetchMissingRoutes(home, missingDests, cacheRef) {
 //   }
 // }
 
+/**
+ * Fetches matrix data + place details for `destinations` relative to `home`,
+ * caching results across renders so changing `home` or adding destinations
+ * only fetches what's missing. Returns rows ready for the table/cards.
+ *
+ * @param {Place|null} home
+ * @param {Place[]} destinations
+ * @returns {{ rows: Row[] }}
+ */
 export function useDestinations(home, destinations) {
   const [rows, setRows] = useState([]);
 

--- a/frontend/hooks/useRouteCache.js
+++ b/frontend/hooks/useRouteCache.js
@@ -2,6 +2,21 @@ import { useState, useEffect, useRef } from 'react';
 import { routesApiClient } from '../config/maps';
 import { useMapFeatures } from '../context/MapContext';
 
+/**
+ * @typedef {import('../types').Place} Place
+ * @typedef {import('../types').GoogleRoute} GoogleRoute
+ * @typedef {import('../types').RouteOptions} RouteOptions
+ */
+
+/**
+ * Fetch a single route from the Routes API, with the "no path found" case
+ * returning null instead of throwing.
+ *
+ * @param {Place} home
+ * @param {Place} dest
+ * @param {RouteOptions} routeOptions
+ * @returns {Promise<GoogleRoute|null>}
+ */
 async function fetchMissingRoute(home, dest, routeOptions) {
   try {
     // 1. Declare with 'const' to keep it local
@@ -23,6 +38,14 @@ async function fetchMissingRoute(home, dest, routeOptions) {
   }
 }
 
+/**
+ * Returns the polyline route for a given destination. Reads from `routesCache`
+ * in MapContext on hit, fetches from the Routes API on miss and writes back.
+ *
+ * @param {Place} destination
+ * @param {RouteOptions} routeOptions
+ * @returns {{ route: GoogleRoute|null }}
+ */
 export function useRouteCache(destination, routeOptions) {
   const { home, routesCache } = useMapFeatures();
   const [route, setRoute] = useState(null);

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -1,0 +1,86 @@
+/**
+ * Shared type definitions. Reference these from other files via:
+ *   /** @typedef {import('../types').Place} Place * /
+ *
+ * Centralized so the same shape isn't redefined in multiple files. If a shape
+ * changes (e.g., Place gets a new field), update it here and every consumer
+ * picks it up automatically in their editor's IntelliSense.
+ */
+
+/**
+ * @typedef {Object} Place
+ * A single location selected from autocomplete + geocoded.
+ * Used as `home`, `destination`, items in `destHistory`, and items in `activeRoutes`.
+ *
+ * @property {'origin'|'dest'} field             - which input the user typed it into
+ * @property {string} label                       - "Chipotle Mexican Grill, Munras Avenue, Monterey, CA, USA"
+ * @property {string} placeId                     - "ChIJl28xQCTkjYAR48CoQtJ6pb4"
+ * @property {number} lat                         - 36.5969267
+ * @property {number} lng                         - -121.8944817
+ */
+
+/**
+ * @typedef {Object} Row
+ * Prepared row of data for display in the table and cards.
+ * Built by `prepRowData()` in `utils/places.js` from a Place + matrix data + place details.
+ *
+ * @property {string} name                        - "Chipotle Mexican Grill, Munras Avenue, Monterey, CA, USA"
+ * @property {string} desPlaceId                  - "ChIJl28xQCTkjYAR48CoQtJ6pb4"
+ * @property {Place} destObj                      - the original Place this row was built from
+ * @property {number} distance                    - meters from origin (e.g. 30353)
+ * @property {number|null} driveTime              - seconds, null if ROUTE_NOT_FOUND
+ * @property {number|null} walkTime               - seconds, null if ROUTE_NOT_FOUND
+ * @property {number|null} transitTime            - seconds, null if ROUTE_NOT_FOUND
+ * @property {number|'N/A'} ratings               - 0-5 from Places API, or 'N/A' if missing
+ * @property {string} cost                        - "$" | "$$" | "$$$" | "$$$$" | "$0" | "N/A"
+ */
+
+/**
+ * @typedef {Object} MatrixCell
+ * One cell of a Routes Matrix API response.
+ * Note: `duration` is a string like "419s" — use `cleanTimeRes()` to convert to seconds.
+ *
+ * @property {number} originIndex
+ * @property {number} destinationIndex
+ * @property {string} duration                    - "419s"
+ * @property {number} distanceMeters
+ * @property {string} [condition]                 - "ROUTE_NOT_FOUND" when no path exists
+ */
+
+/**
+ * @typedef {Object} PlaceDetails
+ * Subset of the Places API v1 response that we read.
+ *
+ * @property {number} [rating]                    - 0-5
+ * @property {string} [priceLevel]                - "PRICE_LEVEL_INEXPENSIVE" etc., mapped via priceMap
+ * @property {string} [id]                        - placeId
+ * @property {Object} [regularOpeningHours]
+ */
+
+/**
+ * @typedef {Object} GoogleRoute
+ * One route from the Routes API. Contains polyline-bearing legs and steps.
+ *
+ * @property {Object[]} legs                      - usually length 1 (no waypoints)
+ * @property {Object} viewport                    - bounding box for the route
+ * @property {{high: {latitude: number, longitude: number}}} viewport
+ * @property {{low: {latitude: number, longitude: number}}}  viewport
+ */
+
+/**
+ * @typedef {Object} CachedRoutes
+ * Shape of `routesCache.current[`${homeId}_${destId}`]` — the polyline cache.
+ * @property {GoogleRoute} route
+ */
+
+/**
+ * @typedef {Object} RouteOptions
+ * Options passed to the Routes API. Most importantly, `travelMode` and (eventually)
+ * `routingPreference: 'TRAFFIC_AWARE'` for the primary route.
+ *
+ * @property {'DRIVE'|'WALK'|'BICYCLE'|'TWO_WHEELER'|'TRANSIT'} travelMode
+ * @property {string} [routingPreference]         - "TRAFFIC_AWARE" | "TRAFFIC_AWARE_OPTIMAL"
+ */
+
+// Make this file a module so @typedef can be referenced via `import('../types')`.
+export {};

--- a/frontend/utils/places.js
+++ b/frontend/utils/places.js
@@ -4,11 +4,20 @@ helper functions for workign with the places api and grouping data into the tabl
 
 import { cleanTimeRes } from './time';
 
-/*
-takes the out of order output from the route matrix api
-and converts it into an object keyed by destination index
-so that the table is filled correctly 
-*/
+/**
+ * @typedef {import('../types').Place} Place
+ * @typedef {import('../types').Row} Row
+ * @typedef {import('../types').MatrixCell} MatrixCell
+ * @typedef {import('../types').PlaceDetails} PlaceDetails
+ */
+
+/**
+ * Takes the out-of-order output from the Routes Matrix API and converts it
+ * into an object keyed by `destinationIndex` so rows can be filled correctly.
+ *
+ * @param {MatrixCell[]} res
+ * @returns {Object<number, MatrixCell>}
+ */
 export function createDataLookup(res){
   if (!res || !Array.isArray(res)) return {};
 
@@ -29,16 +38,14 @@ export const priceMap = {
 };
 
 /**
- * @typedef {Object} DestinationPlace
- * @property {'dest'} field i.e. input type origin or dest
- * @property {string} label i.e. name of locaiton
- * @property {string} placeId gogole place id
- * @property {number} lat
- * @property {number} lng
- */
-
-/**
- * @param {DestinationPlace} dest
+ * Build a single Row from a Place + matrix data + place details.
+ *
+ * @param {Place} dest
+ * @param {MatrixCell} driveData
+ * @param {MatrixCell} walkData
+ * @param {MatrixCell} transitData
+ * @param {PlaceDetails} [placeInfo]
+ * @returns {Row}
  */
 export function prepRowData(dest, driveData, walkData, transitData, placeInfo){
   return {


### PR DESCRIPTION
## Summary

Adds a central \`frontend/types.js\` with the data shapes that flow through the app, and references them from the high-leverage call sites. Editor IntelliSense now shows you what's inside \`home\`, \`destination\`, \`row.driveTime\`, \`useMapFeatures()\`, etc. — no more \`console.log\` to remember field names.

No runtime changes. JSDoc only.

## What's typed

**New file: \`frontend/types.js\`**
- \`Place\` — \`{ field, label, placeId, lat, lng }\`. Used as home / destination / destHistory items / activeRoutes items
- \`Row\` — the prepared shape used by the cards and table
- \`MatrixCell\` — one cell of a Routes Matrix response (note: \`duration\` is the string \`"419s"\`)
- \`PlaceDetails\` — subset of Places API v1 response
- \`GoogleRoute\` — Routes API single-route response
- \`RouteOptions\` — what gets passed as \`travelMode\` / \`routingPreference\`

**Updated:**
- \`MapContext.js\` — adds \`MapFeatures\` typedef covering the entire \`useMapFeatures()\` return shape, with \`@returns {MapFeatures}\` on the hook
- \`useDestinations.js\` — \`@param {Place|null}\`, \`@param {Place[]}\`, \`@returns {{ rows: Row[] }}\`, plus a \`DestinationsCache\` typedef for the internal ref
- \`useRouteCache.js\` — \`@param {Place}\`, \`@param {RouteOptions}\`, \`@returns {{ route: GoogleRoute|null }}\`
- \`utils/places.js\` — proper types on \`createDataLookup\` and \`prepRowData\`
- \`LocationCard.jsx\` — replaces its inline \`place\` typedef with \`@typedef {import('../types').Row}\` so the card's prop type stays in sync with what the hook produces
- \`RouteEntry.jsx\` — typed props (\`destination\`, \`index\`, \`routeOptions\`)

## Pattern

Other files reference shared types like this (no runtime import):

\`\`\`js
/**
 * @typedef {import('../types').Place} Place
 * @typedef {import('../types').Row} Row
 */
\`\`\`

If you change the \`Place\` shape later, update it once in \`types.js\` and every IntelliSense hover updates. If you add a new shape that several files use, define it in \`types.js\` and reference from there.

## What's intentionally not typed

- Trivial component props (no value over reading the JSX)
- Internal helpers where the param name says it all
- Components with no props (\`MultiRoutes\`, layout/button components)

## Test plan

- [ ] In your editor, hover over \`useMapFeatures()\` in any component — should show the full \`MapFeatures\` shape
- [ ] In \`LocationCard.jsx\`, hover \`place.driveTime\` — should show \`number | null\`
- [ ] In \`useDestinations.js\` consumer, hover \`rows[0]\` — should show the \`Row\` shape
- [ ] No new lint errors (one new \"unused import\" warning is from a pre-existing \`defaultColors\` import in LocationCard, not introduced here)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)